### PR TITLE
reload core data on song language change

### DIFF
--- a/app/model/CrawlField.scala
+++ b/app/model/CrawlField.scala
@@ -90,12 +90,12 @@ object AlbumCrawlField {
 sealed abstract class SongCrawlField(
   val name: String,
   val extractValue: Song => Option[String],
-  val save: SongDAO => (SongId, Option[String]) => Future[Int]
+  val save: SongDAO => (SongId, Option[String]) => Future[Int],
+  val reloadCoreData: Boolean = false
 ) extends CrawlField[Song, SongId, SongDAO]
 
 object SongCrawlField {
-  // TODO clear cache and update currentList websocket
-  case object LanguageId extends SongCrawlField("languageId", _.languageId, _.setLanguageId)
+  case object LanguageId extends SongCrawlField("languageId", _.languageId, _.setLanguageId, reloadCoreData=true)
 
   case object UrlWikiEn extends SongCrawlField("urlWikiEn", _.urlWikiEn, _.setUrlWikiEn)
   case object UrlWikiNl extends SongCrawlField("urlWikiNl", _.urlWikiNl, _.setUrlWikiNl)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When accepting a crawl that updates a song’s language, the app now reloads core data and instantly refreshes that song in the current list. This ensures users see up-to-date details without manual refresh.
  * Other accepted fields continue to update as before, maintaining existing cache reload behavior while avoiding unnecessary full reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->